### PR TITLE
Allow container overflow value to be overridden

### DIFF
--- a/src/Popover.tsx
+++ b/src/Popover.tsx
@@ -217,6 +217,8 @@ class Popover extends React.Component<PopoverProps, {}> {
         const { containerStyle } = this.props;
         const container = window.document.createElement('div');
 
+        container.style.overflow = 'hidden';
+
         if (containerStyle) {
             Object.keys(containerStyle).forEach(key => container.style[key as any] = (containerStyle as CSSStyleDeclaration)[key as any]);
         }
@@ -225,7 +227,6 @@ class Popover extends React.Component<PopoverProps, {}> {
         container.style.position = 'absolute';
         container.style.top = '0';
         container.style.left = '0';
-        container.style.overflow = 'hidden';
 
         return container;
     }


### PR DESCRIPTION
Apply overflow hidden as a default but allow overriding

The container overflow style value is explicitly set to 'hidden' after the settings from the containerStyle prop are applied. While I'm sure this intentional this hides box-shadow (and adding padding/margin affects the arrow position). This makes overflow 'hidden' the default but allows overriding via containerStyle (rather than using !important in css). 