### PR TITLE
 Fix compatibility with React v15.

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -17,10 +17,12 @@
   "scripts": {
     "start": "webpack-dev-server --inline --hot"
   },
+  "peerDependencies": {
+    "react": "^15.6.1 || ^16.0.0",
+    "react-dom": "^15.6.1 || ^16.0.0"
+  },
   "dependencies": {
-    "react": "^16.0.0",
-    "react-dom": "^16.0.0",
-    "react-tiny-popover": "^3.2.2",
+    "react-tiny-popover": "file:../../react-tiny-popover",
     "react-virtualized": "^9.10.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     "typescript": "^2.5.3",
     "webpack": "^3.6.0"
   },
-  "dependencies": {
-    "react": "^16.0.0",
-    "react-dom": "^16.0.0"
+  "peerDependencies": {
+    "react": "^15.6.1 || ^16.0.0",
+    "react-dom": "^15.6.1 || ^16.0.0"
   }
 }


### PR DESCRIPTION
Hi, Alex

I've been looking for a while for a functionality that provides your package. Others don't do the job as good as yours. The only one thing, support for React v15 was dropped before some important fixes. So I've devoted some time to try to fix it.

I see that you are moving towards utilizing new React v16 features and probably you wouldn't support React v15. Though so far your package works great with v15 and there are no breaking changes except dependency from React v16.

I've just moved `react` and `react-dom` dependencies to the `peer` dependencies and everything works great with React v15 now.

Probably you could find this change useful and maybe sometimes update npm package ;-)

Thanks.

**PS** During creating the PR I've found another [PR](https://github.com/alexkatz/react-tiny-popover/pull/5) which fixes the same issue.