### PR TITLE
Add optional delay before showing popover

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ import Popover, { ArrowContainer } from 'react-tiny-popover'
 |transitionDuration|```number```||The length of the popover content's fade transition in seconds. Defaults to 0.35.|
 |containerStyle|```object``` (```CSSStyleDeclaration```)||Your popover content is rendered to the DOM in a single container ```div```. If you'd like to apply style directly to this container ```div```, you may do so here! Be aware that as this ```div``` is a DOM element and not a React element, all style values must be strings. For example, 5 pixels must be represented as ```'5px'```, as you'd do with vanilla DOM manipulation in Javascript.|
 |containerClassName|```string```||If you'd like to apply styles to the single container ```div``` that your popover content is rendered within via stylesheets, you can specify a custom className for the container here.|
+|delay|```number```||The delay in milliseconds before the popover is displayed. Defaults to 0|
 
 ### ArrowContainer
 |<b>Property<b>|Type|Required|Description|                                  

--- a/src/Popover.tsx
+++ b/src/Popover.tsx
@@ -19,6 +19,7 @@ class Popover extends React.Component<PopoverProps, {}> {
         position: ['top', 'right', 'left', 'bottom'],
         align: 'center',
         containerClassName: Constants.POPOVER_CONTAINER_CLASS_NAME,
+        delay: 0,
     };
 
     public componentDidMount() {
@@ -63,7 +64,9 @@ class Popover extends React.Component<PopoverProps, {}> {
                 window.addEventListener('resize', this.onResize);
                 window.addEventListener('click', this.onClick);
             }
-            this.renderPopover();
+            window.setTimeout(() => {
+                this.renderPopover();
+            }, this.props.delay);
         } else if (this.popoverDiv && this.popoverDiv.parentNode) {
             this.removePopover();
         }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -43,6 +43,7 @@ export declare interface PopoverProps {
     align?: Align;
     transitionDuration?: number;
     windowBorderPadding?: number;
+    delay?: number;
 }
 
 export declare interface ArrowContainerProps {


### PR DESCRIPTION
Add a delay before they popover is shown. The use case is attaching a
popover to buttons/links on hover. I'd like the user to be able to click
the element without necessarily seeing the popover but if they hesitate
then they see a help message in a popover (something more elaborate than
a regular tooltip).