### PR TITLE
Making sure target is not null for components that renders null for a moment

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-tiny-popover",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/alexkatz/react-tiny-popover.git"

--- a/src/Popover.tsx
+++ b/src/Popover.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { findDOMNode, unstable_renderSubtreeIntoContainer } from 'react-dom';
+import { unstable_renderSubtreeIntoContainer } from 'react-dom';
 import { Constants, arrayUnique } from './util';
 import { ArrowContainer } from './ArrowContainer';
 import { PopoverProps, ContentRenderer, ContentRendererArgs, Position, Align, ContentLocation } from './index';
@@ -24,13 +24,11 @@ class Popover extends React.Component<PopoverProps, {}> {
     public componentDidMount() {
         window.setTimeout(() => this.willMount = false);
         const { position, isOpen } = this.props;
-        this.target = findDOMNode(this) as Element;
         this.positionOrder = this.getPositionPriorityOrder(position);
         this.updatePopover(isOpen);
     }
 
     public componentDidUpdate(prevProps: PopoverProps) {
-        this.target = findDOMNode(this) as Element;
         const { isOpen: prevIsOpen, position: prevPosition, content: prevBody } = prevProps;
         const { isOpen, content, position } = this.props;
         this.positionOrder = this.getPositionPriorityOrder(this.props.position);
@@ -50,7 +48,8 @@ class Popover extends React.Component<PopoverProps, {}> {
     }
 
     public render() {
-        return this.props.children;
+        const childElement = React.Children.only(this.props.children);
+		return React.cloneElement(childElement, { ref: el => this.target = el });
     }
 
     private updatePopover(isOpen: boolean) {

--- a/src/Popover.tsx
+++ b/src/Popover.tsx
@@ -30,6 +30,7 @@ class Popover extends React.Component<PopoverProps, {}> {
     }
 
     public componentDidUpdate(prevProps: PopoverProps) {
+        this.target = findDOMNode(this) as Element;
         const { isOpen: prevIsOpen, position: prevPosition, content: prevBody } = prevProps;
         const { isOpen, content, position } = this.props;
         this.positionOrder = this.getPositionPriorityOrder(this.props.position);

--- a/src/Popover.tsx
+++ b/src/Popover.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { unstable_renderSubtreeIntoContainer } from 'react-dom';
+import { findDOMNode, unstable_renderSubtreeIntoContainer } from 'react-dom';
 import { Constants, arrayUnique } from './util';
 import { ArrowContainer } from './ArrowContainer';
 import { PopoverProps, ContentRenderer, ContentRendererArgs, Position, Align, ContentLocation } from './index';
@@ -24,6 +24,7 @@ class Popover extends React.Component<PopoverProps, {}> {
     public componentDidMount() {
         window.setTimeout(() => this.willMount = false);
         const { position, isOpen } = this.props;
+        this.target = findDOMNode(this) as Element;
         this.positionOrder = this.getPositionPriorityOrder(position);
         this.updatePopover(isOpen);
     }
@@ -48,8 +49,7 @@ class Popover extends React.Component<PopoverProps, {}> {
     }
 
     public render() {
-        const childElement = React.Children.only(this.props.children);
-		return React.cloneElement(childElement, { ref: el => this.target = el });
+        return this.props.children;
     }
 
     private updatePopover(isOpen: boolean) {

--- a/src/Popover.tsx
+++ b/src/Popover.tsx
@@ -29,7 +29,7 @@ class Popover extends React.Component<PopoverProps, {}> {
         this.updatePopover(isOpen);
     }
 
-    public componentDidUpdate(prevProps: PopoverProps) {;
+    public componentDidUpdate(prevProps: PopoverProps) {
         this.target = findDOMNode(this) as Element;
         const { isOpen: prevIsOpen, position: prevPosition, content: prevBody } = prevProps;
         const { isOpen, content, position } = this.props;

--- a/src/Popover.tsx
+++ b/src/Popover.tsx
@@ -29,7 +29,8 @@ class Popover extends React.Component<PopoverProps, {}> {
         this.updatePopover(isOpen);
     }
 
-    public componentDidUpdate(prevProps: PopoverProps) {
+    public componentDidUpdate(prevProps: PopoverProps) {;
+        this.target = findDOMNode(this) as Element;
         const { isOpen: prevIsOpen, position: prevPosition, content: prevBody } = prevProps;
         const { isOpen, content, position } = this.props;
         this.positionOrder = this.getPositionPriorityOrder(this.props.position);


### PR DESCRIPTION
This fix comes when target (children) element sometimes renders null, so target will be null when popover componentDidMount is called making the popover to break.
An use case of this is a themed button, so it renders null until theme data is loaded asynchronously, so HTML won't appear in the UI until CSS is ready, instead of having the mark up rendered with no styles and this way we avoid UI flickering. So by the time popover is mounted it is not possible to get the target and when target element is clicked popover will break the whole page.

This change makes sure to calculate target every time the popover is updated.