### PR TITLE
Check null popoverDiv before remove

### DIFF
--- a/src/Popover.tsx
+++ b/src/Popover.tsx
@@ -47,7 +47,7 @@ class Popover extends React.Component<PopoverProps, {}> {
         ) {
             if (hasNewDestination) {
                 this.removePopover();
-                this.popoverDiv.remove();
+                this.popoverDiv && this.popoverDiv.remove();
             }
 
             this.updatePopover(isOpen);


### PR DESCRIPTION
Fix https://github.com/alexkatz/react-tiny-popover/issues/33

Actually when we pass contentDestination that time it's checking differences for popoverDiv then it's removing old popoverDiv. But problem is initially it's having null that's why it's throwing an error.