### PR TITLE
added ie flicker fix

### DIFF
--- a/src/usePopover.ts
+++ b/src/usePopover.ts
@@ -21,6 +21,7 @@ export const usePopover = ({
     overflow: 'visible',
     top: '0px',
     left: '0px',
+    opacity: '0',
   });
 
   const positionPopover = useCallback<PositionPopover>(
@@ -49,6 +50,7 @@ export const usePopover = ({
             : contentLocation;
 
         popoverRef.current.style.transform = `translate(${left}px, ${top}px)`;
+        popoverRef.current.style.opacity = '1';
 
         onPositionPopover({
           isPositioned: true,
@@ -102,6 +104,7 @@ export const usePopover = ({
       }
 
       popoverRef.current.style.transform = `translate(${finalLeft}px, ${finalTop}px)`;
+      popoverRef.current.style.opacity = '1';
 
       onPositionPopover({
         isPositioned: true,


### PR DESCRIPTION
**ISSUE**
we were noticing a flicker in IE where the popover would briefly appear at `top: 0; left: 0;` before being positioned (screen recording included for reference)

[react-tiny-popover-flicker.mp4.zip](https://github.com/alexkatz/react-tiny-popover/files/5336329/react-tiny-popover-flicker.mp4.zip)

**SUGGESTED SOLUTION**
set opacity of popover to 0 by default, which will hide the popover when is set to 0,0 position. then once translate is set, updates opacity to 1.