### PR TITLE
Fix eslint problems in custom component example

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,14 +120,16 @@ import React, { useState } from 'react';
 import { Popover } from 'react-tiny-popover';
 
 interface CustomComponentProps extends React.ComponentPropsWithoutRef<'div'> {
-  onClick(): void;
+  onClick: () => void;
 }
 
-const CustomComponent = React.forwardRef<HTMLDivElement, CustomComponentProps>((props, ref) => (
+const CustomComponent = React.forwardRef<HTMLDivElement, CustomComponentProps>((props: { onClick: () => void; children?: React.ReactNode }, ref) => (
   <div ref={ref} onClick={props.onClick}>
     {props.children}
   </div>
 ));
+
+CustomComponent.displayName = "CustomComponent";
 
 const App: React.FC = () => {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);


### PR DESCRIPTION
When using the custom component example, eslint complained about multiple problems (`react/prop-types children; is missing in props validation`, `Component definition is missing display name react/display-name`, and some third one).
This commit should fix those errors.