### PR TITLE
use arrowClassName prop

### DIFF
--- a/src/ArrowContainer.tsx
+++ b/src/ArrowContainer.tsx
@@ -8,6 +8,7 @@ export const ArrowContainer: React.FC<ArrowContainerProps> = ({
   position,
   arrowColor,
   arrowSize,
+  arrowClassName,
   arrowStyle: externalArrowStyle,
   className,
   children,
@@ -39,7 +40,7 @@ export const ArrowContainer: React.FC<ArrowContainerProps> = ({
 
   return (
     <div className={className} style={mergedContainerStyle}>
-      <div style={mergedArrowStyle} />
+      <div style={mergedArrowStyle} className={arrowClassName} />
       {children}
     </div>
   );


### PR DESCRIPTION
In the props for ArrowContainer, there is an optional `arrowClassName` prop that is never accessed. This simply adds it to the arrow div as (presumably) intended.