### PR TITLE
Updated React peer dependencies to use 16 and 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-tiny-popover",
-  "version": "6.0.5",
+  "version": "6.0.6",
   "description": "A simple and highly customizable popover react higher order component with no other dependencies! Typescript friendly.",
   "keywords": [
     "react",
@@ -52,7 +52,7 @@
     "typescript": "^4.0.2"
   },
   "peerDependencies": {
-    "react": "^16.0.0",
-    "react-dom": "^16.0.0"
+    "react": "^16.0.0 || ^17.0.0",
+    "react-dom": "^16.0.0 || ^17.0.0"
   }
 }


### PR DESCRIPTION
I am using this in a React 17 project without any problems, it's safe to update the peer dependencies. This will fix #103 