### PR TITLE
resize throws error Cannot read property 'getBoundingClientRect' 

### DIFF
--- a/src/Popover.tsx
+++ b/src/Popover.tsx
@@ -179,7 +179,9 @@ export const Popover = forwardRef<HTMLElement, PopoverProps>(
     );
 
     const handleWindowResize = useCallback(() => {
-      window.requestAnimationFrame(() => positionPopover());
+      if(childRef?.current){
+        window.requestAnimationFrame(() => positionPopover());
+      }
     }, [positionPopover]);
 
     useEffect(() => {


### PR DESCRIPTION
Great package! 

Using it quite a bit. This is to fix #100