### PR TITLE
Fix an error connected with source maps urls

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "url": "https://github.com/alexkatz/react-tiny-popover.git"
   },
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "license": "MIT",
   "author": "Alex Katz",


### PR DESCRIPTION
Hello. Connected with #121 and #88.

Added an `src` directory to the npm package to allow source map resolving for users of the library. Previously it was broken because of `source` in `map.js` pointed to `.tsx/.ts` files that did not exist in the resulting package. 