### PR TITLE
Improve typings and error safety

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "tsc-watch": "^4.0.0",
-    "typescript": "^4.0.2"
+    "typescript": "4.3.5"
   },
   "peerDependencies": {
     "react": "^16.0.0 || ^17.0.0",

--- a/src/Popover.tsx
+++ b/src/Popover.tsx
@@ -1,6 +1,19 @@
-import React, { useRef, useLayoutEffect, useState, useCallback, useEffect, forwardRef } from 'react';
+import React, {
+  useRef,
+  useLayoutEffect,
+  useState,
+  useCallback,
+  useEffect,
+  forwardRef,
+} from 'react';
 import { PopoverPortal } from './PopoverPortal';
-import { ContentLocation, ContentLocationGetter, PopoverPosition, PopoverProps, PopoverState } from '.';
+import {
+  ContentLocation,
+  ContentLocationGetter,
+  PopoverPosition,
+  PopoverProps,
+  PopoverState,
+} from '.';
 import { Constants, rectsAreEqual } from './util';
 import { usePopover } from './usePopover';
 import { useMemoizedArray } from './useMemoizedArray';
@@ -26,7 +39,7 @@ export const Popover = forwardRef<HTMLElement, PopoverProps>(
       boundaryInset = 0,
       onClickOutside,
     },
-    externalRef
+    externalRef,
   ) => {
     const positions = useMemoizedArray(externalPositions);
 
@@ -50,7 +63,10 @@ export const Popover = forwardRef<HTMLElement, PopoverProps>(
       boundaryInset,
     });
 
-    const onPositionPopover = useCallback((popoverState: PopoverState) => setPopoverState(popoverState), []);
+    const onPositionPopover = useCallback(
+      (popoverState: PopoverState) => setPopoverState(popoverState),
+      [],
+    );
 
     const [positionPopover, popoverRef] = usePopover({
       childRef,
@@ -141,18 +157,25 @@ export const Popover = forwardRef<HTMLElement, PopoverProps>(
 
       return () => {
         Object.keys(containerStyle ?? {}).forEach(
-          key => delete popoverElement.style[key as keyof Omit<typeof containerStyle, 'length' | 'parentRule'>]
+          (key) =>
+            delete popoverElement.style[
+              key as keyof Omit<typeof containerStyle, 'length' | 'parentRule'>
+            ],
         );
       };
     }, [containerStyle, isOpen, popoverRef]);
 
     const handleOnClickOutside = useCallback(
       (e: MouseEvent) => {
-        if (isOpen && !popoverRef.current?.contains(e.target as Node) && !childRef.current?.contains(e.target as Node)) {
+        if (
+          isOpen &&
+          !popoverRef.current?.contains(e.target as Node) &&
+          !childRef.current?.contains(e.target as Node)
+        ) {
           onClickOutside?.(e);
         }
       },
-      [isOpen, onClickOutside, popoverRef]
+      [isOpen, onClickOutside, popoverRef],
     );
 
     const handleWindowResize = useCallback(() => {
@@ -181,7 +204,7 @@ export const Popover = forwardRef<HTMLElement, PopoverProps>(
           }
         }
       },
-      [externalRef]
+      [externalRef],
     );
 
     const renderChild = () =>
@@ -204,5 +227,5 @@ export const Popover = forwardRef<HTMLElement, PopoverProps>(
         {renderPopover()}
       </>
     );
-  }
+  },
 );

--- a/src/Popover.tsx
+++ b/src/Popover.tsx
@@ -1,19 +1,6 @@
-import React, {
-  useRef,
-  useLayoutEffect,
-  useState,
-  useCallback,
-  useEffect,
-  forwardRef,
-} from 'react';
+import React, { useRef, useLayoutEffect, useState, useCallback, useEffect, forwardRef } from 'react';
 import { PopoverPortal } from './PopoverPortal';
-import {
-  ContentLocation,
-  ContentLocationGetter,
-  PopoverPosition,
-  PopoverProps,
-  PopoverState,
-} from '.';
+import { ContentLocation, ContentLocationGetter, PopoverPosition, PopoverProps, PopoverState } from '.';
 import { Constants, rectsAreEqual } from './util';
 import { usePopover } from './usePopover';
 import { useMemoizedArray } from './useMemoizedArray';
@@ -39,7 +26,7 @@ export const Popover = forwardRef<HTMLElement, PopoverProps>(
       boundaryInset = 0,
       onClickOutside,
     },
-    externalRef,
+    externalRef
   ) => {
     const positions = useMemoizedArray(externalPositions);
 
@@ -63,10 +50,7 @@ export const Popover = forwardRef<HTMLElement, PopoverProps>(
       boundaryInset,
     });
 
-    const onPositionPopover = useCallback(
-      (popoverState: PopoverState) => setPopoverState(popoverState),
-      [],
-    );
+    const onPositionPopover = useCallback((popoverState: PopoverState) => setPopoverState(popoverState), []);
 
     const [positionPopover, popoverRef] = usePopover({
       childRef,
@@ -157,25 +141,18 @@ export const Popover = forwardRef<HTMLElement, PopoverProps>(
 
       return () => {
         Object.keys(containerStyle ?? {}).forEach(
-          (key) =>
-            (popoverElement.style[
-              key as keyof Omit<typeof containerStyle, 'length' | 'parentRule'>
-            ] = null),
+          key => delete popoverElement.style[key as keyof Omit<typeof containerStyle, 'length' | 'parentRule'>]
         );
       };
     }, [containerStyle, isOpen, popoverRef]);
 
     const handleOnClickOutside = useCallback(
       (e: MouseEvent) => {
-        if (
-          isOpen &&
-          !popoverRef.current?.contains(e.target as Node) &&
-          !childRef.current?.contains(e.target as Node)
-        ) {
+        if (isOpen && !popoverRef.current?.contains(e.target as Node) && !childRef.current?.contains(e.target as Node)) {
           onClickOutside?.(e);
         }
       },
-      [isOpen, onClickOutside, popoverRef],
+      [isOpen, onClickOutside, popoverRef]
     );
 
     const handleWindowResize = useCallback(() => {
@@ -204,7 +181,7 @@ export const Popover = forwardRef<HTMLElement, PopoverProps>(
           }
         }
       },
-      [externalRef],
+      [externalRef]
     );
 
     const renderChild = () =>
@@ -227,5 +204,5 @@ export const Popover = forwardRef<HTMLElement, PopoverProps>(
         {renderPopover()}
       </>
     );
-  },
+  }
 );

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -69,7 +69,12 @@ export interface PopoverProps {
   onClickOutside?: (e: MouseEvent) => void;
 }
 
-export type PositionPopover = (positionIndex?: number, childRect?: ClientRect, popoverRect?: ClientRect, parentRect?: ClientRect) => void;
+export type PositionPopover = (
+  positionIndex?: number,
+  childRect?: ClientRect,
+  popoverRect?: ClientRect,
+  parentRect?: ClientRect,
+) => void;
 
 export type UsePopoverResult = readonly [PositionPopover, React.MutableRefObject<HTMLDivElement>];
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -18,6 +18,7 @@ export interface PopoverState {
 export type ContentRenderer = (popoverState: PopoverState) => JSX.Element;
 export type ContentLocationGetter = (popoverState: PopoverState) => ContentLocation;
 
+export type PopoverPositionBase = 'left' | 'right' | 'top' | 'bottom';
 export type PopoverPosition = 'left' | 'right' | 'top' | 'bottom' | 'custom';
 export type PopoverAlign = 'start' | 'center' | 'end' | 'custom';
 
@@ -38,7 +39,7 @@ export interface ArrowContainerProps extends UseArrowContainerProps {
 }
 
 export interface UsePopoverProps {
-  childRef: React.MutableRefObject<HTMLElement>;
+  childRef: React.MutableRefObject<HTMLElement | undefined>;
   positions?: PopoverPosition[];
   align?: PopoverAlign;
   padding: number;
@@ -68,12 +69,7 @@ export interface PopoverProps {
   onClickOutside?: (e: MouseEvent) => void;
 }
 
-export type PositionPopover = (
-  positionIndex?: number,
-  childRect?: ClientRect,
-  popoverRect?: ClientRect,
-  parentRect?: ClientRect,
-) => void;
+export type PositionPopover = (positionIndex?: number, childRect?: ClientRect, popoverRect?: ClientRect, parentRect?: ClientRect) => void;
 
 export type UsePopoverResult = readonly [PositionPopover, React.MutableRefObject<HTMLDivElement>];
 

--- a/src/usePopover.ts
+++ b/src/usePopover.ts
@@ -27,7 +27,7 @@ export const usePopover = ({
       positionIndex: number = 0,
       childRect: ClientRect | undefined = childRef?.current?.getBoundingClientRect(),
       popoverRect: ClientRect = popoverRef.current.getBoundingClientRect(),
-      parentRect: ClientRect | undefined = containerParent?.getBoundingClientRect()
+      parentRect: ClientRect | undefined = containerParent?.getBoundingClientRect(),
     ) => {
       if (!childRect || !parentRect) {
         return;
@@ -85,7 +85,7 @@ export const usePopover = ({
           padding,
           reposition,
         },
-        boundaryInset
+        boundaryInset,
       );
 
       if (boundaryViolation && reposition && !isExhausted) {
@@ -95,7 +95,11 @@ export const usePopover = ({
 
       const { top, left, width, height } = rect;
       const shouldNudge = reposition && !isExhausted;
-      const { left: nudgedLeft, top: nudgedTop } = getNudgedPopoverRect(rect, parentRect, boundaryInset);
+      const { left: nudgedLeft, top: nudgedTop } = getNudgedPopoverRect(
+        rect,
+        parentRect,
+        boundaryInset,
+      );
 
       let finalTop = top;
       let finalLeft = left;
@@ -126,7 +130,18 @@ export const usePopover = ({
         boundaryInset,
       });
     },
-    [childRef, popoverRef, positions, align, padding, reposition, boundaryInset, containerParent, contentLocation, onPositionPopover]
+    [
+      childRef,
+      popoverRef,
+      positions,
+      align,
+      padding,
+      reposition,
+      boundaryInset,
+      containerParent,
+      contentLocation,
+      onPositionPopover,
+    ],
   );
 
   return [positionPopover, popoverRef];

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,4 @@
-import { PopoverPosition, PopoverState, PopoverAlign } from './index';
+import { PopoverPosition, PopoverState, PopoverAlign, PopoverPositionBase } from './index';
 
 export const Constants = {
   POPOVER_CONTAINER_CLASS_NAME: 'react-tiny-popover-container',
@@ -18,8 +18,7 @@ export const Constants = {
   } as ClientRect,
 } as const;
 
-export const arrayUnique = <T>(array: T[]): T[] =>
-  array.filter((value: any, index: number, self: T[]) => self.indexOf(value) === index);
+export const arrayUnique = <T>(array: T[]): T[] => array.filter((value: any, index: number, self: T[]) => self.indexOf(value) === index);
 
 export const rectsAreEqual = (rectA: ClientRect, rectB: ClientRect) =>
   rectA === rectB ||
@@ -47,10 +46,7 @@ export const targetPositionHasChanged = (oldRect: ClientRect, newRect: ClientRec
   oldRect.width !== newRect.width ||
   oldRect.height !== newRect.height;
 
-export const createContainer = (
-  containerStyle?: Partial<CSSStyleDeclaration>,
-  containerClassName?: string,
-) => {
+export const createContainer = (containerStyle?: Partial<CSSStyleDeclaration>, containerClassName?: string) => {
   const container = window.document.createElement('div');
   if (containerClassName) container.className = containerClassName;
   Object.assign(container.style, containerStyle);
@@ -58,11 +54,11 @@ export const createContainer = (
 };
 
 export const popoverRectForPosition = (
-  position: PopoverPosition,
+  position: PopoverPositionBase,
   childRect: ClientRect,
   popoverRect: ClientRect,
   padding: number,
-  align: PopoverAlign,
+  align: PopoverAlign
 ): ClientRect => {
   const targetMidX = childRect.left + childRect.width / 2;
   const targetMidY = childRect.top + childRect.height / 2;
@@ -71,16 +67,6 @@ export const popoverRectForPosition = (
   let left: number;
 
   switch (position) {
-    case 'top':
-      top = childRect.top - height - padding;
-      left = targetMidX - width / 2;
-      if (align === 'start') {
-        left = childRect.left;
-      }
-      if (align === 'end') {
-        left = childRect.right - width;
-      }
-      break;
     case 'left':
       top = targetMidY - height / 2;
       left = childRect.left - padding - width;
@@ -112,6 +98,14 @@ export const popoverRectForPosition = (
       }
       break;
     default:
+      top = childRect.top - height - padding;
+      left = targetMidX - width / 2;
+      if (align === 'start') {
+        left = childRect.left;
+      }
+      if (align === 'end') {
+        left = childRect.right - width;
+      }
       break;
   }
 
@@ -119,7 +113,7 @@ export const popoverRectForPosition = (
 };
 
 interface GetNewPopoverRectProps {
-  position: PopoverPosition;
+  position: PopoverPositionBase;
   reposition: boolean;
   align: PopoverAlign;
   childRect: ClientRect;
@@ -129,16 +123,8 @@ interface GetNewPopoverRectProps {
 }
 
 export const getNewPopoverRect = (
-  {
-    position,
-    align,
-    childRect,
-    popoverRect,
-    parentRect,
-    padding,
-    reposition,
-  }: GetNewPopoverRectProps,
-  boundaryInset: number,
+  { position, align, childRect, popoverRect, parentRect, padding, reposition }: GetNewPopoverRectProps,
+  boundaryInset: number
 ) => {
   const rect = popoverRectForPosition(position, childRect, popoverRect, padding, align);
   const boundaryViolation =
@@ -154,11 +140,7 @@ export const getNewPopoverRect = (
   };
 };
 
-export const getNudgedPopoverRect = (
-  popoverRect: ClientRect,
-  parentRect: ClientRect,
-  boundaryInset: number,
-): ClientRect => {
+export const getNudgedPopoverRect = (popoverRect: ClientRect, parentRect: ClientRect, boundaryInset: number): ClientRect => {
   const topBoundary = parentRect.top + boundaryInset;
   const leftBoundary = parentRect.left + boundaryInset;
   const rightBoundary = parentRect.right - boundaryInset;

--- a/src/util.ts
+++ b/src/util.ts
@@ -18,7 +18,8 @@ export const Constants = {
   } as ClientRect,
 } as const;
 
-export const arrayUnique = <T>(array: T[]): T[] => array.filter((value: any, index: number, self: T[]) => self.indexOf(value) === index);
+export const arrayUnique = <T>(array: T[]): T[] =>
+  array.filter((value: any, index: number, self: T[]) => self.indexOf(value) === index);
 
 export const rectsAreEqual = (rectA: ClientRect, rectB: ClientRect) =>
   rectA === rectB ||
@@ -46,7 +47,10 @@ export const targetPositionHasChanged = (oldRect: ClientRect, newRect: ClientRec
   oldRect.width !== newRect.width ||
   oldRect.height !== newRect.height;
 
-export const createContainer = (containerStyle?: Partial<CSSStyleDeclaration>, containerClassName?: string) => {
+export const createContainer = (
+  containerStyle?: Partial<CSSStyleDeclaration>,
+  containerClassName?: string,
+) => {
   const container = window.document.createElement('div');
   if (containerClassName) container.className = containerClassName;
   Object.assign(container.style, containerStyle);
@@ -58,7 +62,7 @@ export const popoverRectForPosition = (
   childRect: ClientRect,
   popoverRect: ClientRect,
   padding: number,
-  align: PopoverAlign
+  align: PopoverAlign,
 ): ClientRect => {
   const targetMidX = childRect.left + childRect.width / 2;
   const targetMidY = childRect.top + childRect.height / 2;
@@ -123,8 +127,16 @@ interface GetNewPopoverRectProps {
 }
 
 export const getNewPopoverRect = (
-  { position, align, childRect, popoverRect, parentRect, padding, reposition }: GetNewPopoverRectProps,
-  boundaryInset: number
+  {
+    position,
+    align,
+    childRect,
+    popoverRect,
+    parentRect,
+    padding,
+    reposition,
+  }: GetNewPopoverRectProps,
+  boundaryInset: number,
 ) => {
   const rect = popoverRectForPosition(position, childRect, popoverRect, padding, align);
   const boundaryViolation =
@@ -140,7 +152,11 @@ export const getNewPopoverRect = (
   };
 };
 
-export const getNudgedPopoverRect = (popoverRect: ClientRect, parentRect: ClientRect, boundaryInset: number): ClientRect => {
+export const getNudgedPopoverRect = (
+  popoverRect: ClientRect,
+  parentRect: ClientRect,
+  boundaryInset: number,
+): ClientRect => {
   const topBoundary = parentRect.top + boundaryInset;
   const leftBoundary = parentRect.left + boundaryInset;
   const rightBoundary = parentRect.right - boundaryInset;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1969,10 +1969,10 @@ type-fest@^0.8.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
-typescript@^4.0.2:
-  version "4.3.2"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-4.3.2.tgz#399ab18aac45802d6f2498de5054fcbbe716a805"
-  integrity sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==
+typescript@4.3.5:
+  version "4.3.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
+  integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
 
 unbox-primitive@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
I cloned this library locally to investigate [this bug](https://github.com/alexkatz/react-tiny-popover/issues/100#issue-786876258). Thankfully this was fixed in v6.0.6 but in the process of my investigation, I realised some of the typings are not as safe as they can be. Upgrading to the latest version of typescript highlighted these errors - so I thought I'd submit a PR with the updated typescript library and typings.

I will comment on the PR to explain what I have done at each stage.
