### PR TITLE
Support text selection inside the popover

### DIFF
--- a/src/Popover.tsx
+++ b/src/Popover.tsx
@@ -238,7 +238,7 @@ const PopoverInternal = forwardRef<HTMLElement, PopoverProps>(
         window.removeEventListener('mouseup', handleMouseUp);
         window.removeEventListener('mousedown', handleMouseDown);
       };
-    }, [handleOnClickOutside, handleWindowResize]);
+    }, [handleOnClickOutside, handleWindowResize, handleMouseUp, handleMouseDown]);
 
     const handleRef = useCallback(
       (node: HTMLElement) => {


### PR DESCRIPTION
There is already existing PR for solving text selection inside Popover https://github.com/alexkatz/react-tiny-popover/pull/87.
But there is several concerns in that PR:

1. It shares information of mouse actions in one place and could be used by many Popover instances, what is not actually good. Some opened Popover may affect another one.
2. It subscribes `mousedown` event to `popoverRef`, not to the `window`. So sometimes if you have two popovers - you can open both of them, and after releasing click outside it will close only one.

This PR solves listed issues above by incapsulating `mouseup` / `mousedown` information into `useRef`, so it avoids information sharing between multiple instances. `useState` is not suitable in that case, as `handleOnClickOutside` released straight after `handleMouseUp`, so handler will get updated state from `handleMouseDown` only in next render interation after it released.