### PR TITLE
Fix blurry popover on non-retina displays

### DIFF
--- a/src/usePopover.ts
+++ b/src/usePopover.ts
@@ -71,8 +71,8 @@ export const usePopover = ({
         const left = parentRect.left + inputLeft;
         const top = parentRect.top + inputTop;
 
-        popoverRef.current.style.transform = `translate(${left - scoutRect.left}px, ${
-          top - scoutRect.top
+        popoverRef.current.style.transform = `translate(${Math.round(left - scoutRect.left)}px, ${
+          Math.round(top - scoutRect.top)
         }px)`;
 
         onPositionPopover({


### PR DESCRIPTION
When using popovers on a non-Retina/high pixel density screen, there are som situations where it becomes totally blurry due to calculations of positions returning decimal values for pixel position.

The worst case is when a `.5px` value is output where the effect is the worst because the browser will try to put it between the two pixel positions and anti-alias everything which will make it totally blurry like the exemple bellow:

![Screenshot 2022-09-30 at 15 14 09](https://user-images.githubusercontent.com/1787785/198032315-36382ec9-2b2d-4206-b289-0a221ab9a302.png)

Plus the decimal of a pixel doesn't really make sense in general as it translates to a physical limitation of a pixel not being dividable. On Retina displays it works because each pixel is actually made of multiple pixels so you don't have to use anti-aliasing as much

So the fix is simple, just round the position 😛 

Thank you for your work and maintaining the library!