### PR TITLE
Fix blur on non-retina displays + popover overflow

### DIFF
--- a/src/usePopover.ts
+++ b/src/usePopover.ts
@@ -135,7 +135,7 @@ export const usePopover = ({
       finalTop = Math.round(finalTop - scoutRect.top);
       finalLeft = Math.round(finalLeft - scoutRect.left);
 
-      popoverRef.current.style.transform = `translate(${left}px, ${top}px)`;
+      popoverRef.current.style.transform = `translate(${finalLeft}px, ${finalTop}px)`;
 
       const potentialViolations: BoundaryViolations = {
         top: boundaryRect.top + boundaryInset - finalTop,


### PR DESCRIPTION
This PR fixes a regression introduced in d4eac0a767594732308699c357185053263c1cd7 which allowed the popover to appear outside the viewport. The actual transform style applied did not take the scoutRect into account anymore.

Additionally, this fix also addresses the blurry dropdown issue on non-retina displays as initially intended by #176.