### PR TITLE
Allow passing a function to `align`

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -42,7 +42,11 @@ export type PositionTransform =
   | ((popoverState: PopoverState) => PositionTransformValue);
 
 export type PopoverPosition = 'left' | 'right' | 'top' | 'bottom';
-export type PopoverAlign = 'start' | 'center' | 'end';
+export type PopoverAlignValue = 'start' | 'center' | 'end';
+
+export type PopoverAlign =
+  | PopoverAlignValue
+  | ((popoverPosition: PopoverPosition) => PopoverAlignValue);
 
 export type UseArrowContainerProps = {
   childRect: Rect;

--- a/src/usePopover.ts
+++ b/src/usePopover.ts
@@ -48,8 +48,8 @@ export const usePopover = ({
   const popoverRef = useElementRef({
     containerClassName:
       containerClassName != null &&
-      containerClassName.length > 0 &&
-      containerClassName !== 'react-tiny-popover-container'
+        containerClassName.length > 0 &&
+        containerClassName !== 'react-tiny-popover-container'
         ? `react-tiny-popover-container ${containerClassName}`
         : 'react-tiny-popover-container',
     containerStyle: POPOVER_STYLE,
@@ -74,18 +74,18 @@ export const usePopover = ({
         const { top: inputTop, left: inputLeft } =
           typeof transform === 'function'
             ? transform({
-                childRect,
-                popoverRect,
-                parentRect,
-                boundaryRect,
-                padding,
-                align,
-                nudgedTop: 0,
-                nudgedLeft: 0,
-                boundaryInset,
-                violations: EMPTY_RECT,
-                hasViolations: false,
-              })
+              childRect,
+              popoverRect,
+              parentRect,
+              boundaryRect,
+              padding,
+              align,
+              nudgedTop: 0,
+              nudgedLeft: 0,
+              boundaryInset,
+              violations: EMPTY_RECT,
+              hasViolations: false,
+            })
             : transform;
 
         const finalLeft = Math.round(parentRect.left + inputLeft - scoutRect.left);
@@ -119,13 +119,15 @@ export const usePopover = ({
       const isExhausted = positionIndex === positions.length;
       const position = isExhausted ? positions[0] : positions[positionIndex];
 
+      const calculatedAlign = typeof align === 'function' ? align(position) : align;
+
       const { rect, boundaryViolation } = getNewPopoverRect(
         {
           childRect,
           popoverRect,
           boundaryRect,
           position,
-          align,
+          align: calculatedAlign,
           padding,
           reposition,
         },


### PR DESCRIPTION
Allows passing a function to `align`, to determine the alignment based off of the position, e.g.:

```js
function getAlignment(position) {
  return position === 'bottom' ? 'end' : 'center';
}
<Popover
  isOpen={true}
  positions={['bottom', 'left']}
  align={getAlignment}
  content={<div>example</div>}
>
  Click me
</Popover>
```

See https://github.com/alexkatz/react-tiny-popover/issues/206