### PR TITLE
Update type definitions to support React 19

### DIFF
--- a/src/Popover.tsx
+++ b/src/Popover.tsx
@@ -55,7 +55,7 @@ const PopoverInternal = forwardRef(
       boundaryInset,
     });
 
-    const childRef = useRef<HTMLElement | undefined>();
+    const childRef = useRef<HTMLElement | undefined>(undefined);
 
     const [popoverState, setPopoverState] = useState<PopoverState>({
       align,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,3 +1,5 @@
+import type { JSX } from 'react';
+
 export type Rect = {
   top: number;
   left: number;

--- a/src/useElementRef.ts
+++ b/src/useElementRef.ts
@@ -2,7 +2,7 @@ import { useRef, useState, useLayoutEffect } from 'react';
 import { CreateContainerProps, createContainer } from './util';
 
 export const useElementRef = ({ containerClassName, containerStyle }: CreateContainerProps) => {
-  const ref = useRef<HTMLDivElement>();
+  const ref = useRef<HTMLDivElement>(undefined);
 
   const [element] = useState(() =>
     createContainer({ containerStyle, containerClassName: containerClassName }),


### PR DESCRIPTION
Hi @alexkatz, thank you very much for your great work!
I have created this PR to make this library compatible with React 19!

In React 19, [the global JSX namespace has been removed](https://react.dev/blog/2024/04/25/react-19-upgrade-guide#the-jsx-namespace-in-typescript), so `JSX.Element` cannot be resolved and is treated as `any`. In this PR, an `import` statement is added so that `JSX.Element` is correctly referenced.

Also, [the `useRef` now requires an argument in React 19](https://react.dev/blog/2024/04/25/react-19-upgrade-guide#useref-requires-argument), so I explicitly added `undefined` to the `useRef()`.